### PR TITLE
Signal scaling in fastplot

### DIFF
--- a/gui/fastplot/fastplot.m
+++ b/gui/fastplot/fastplot.m
@@ -195,7 +195,7 @@ classdef fastplot < handle
         function refresh(obj, elements, mthd)
             % refresh fastplot window
 
-            % CHANGE should check if sth actually changed
+            % CHANGE maybe should check if sth actually changed
 
             % during re-plotting:
             % always use set 'XData', 'YData'

--- a/gui/fastplot/fastplot.m
+++ b/gui/fastplot/fastplot.m
@@ -38,6 +38,11 @@ classdef fastplot < handle
     %     selected    - M by E boolean matrix; informs which epochs are marked
     %                   with which mark types (M - number of marks, E - number
     %                   of epochs)
+    % opt      -  various options, including:
+    %    .step    - step values for different movement and scaling types:
+    %         .epoch_move
+    %         .epoch_scale
+    %         .signal_scale
     % keys     -  a KeyboardManager instance - it is responsible for keyboard
     %             interactions with the gui including sequences of key presses
 
@@ -82,6 +87,11 @@ classdef fastplot < handle
     methods
         
         function obj = fastplot(EEG, varargin)
+
+            % default opt settings
+            obj.opt.step.move_unit = 'epoch';
+            obj.opt.step.move = 1;
+            obj.opt.step.epoch_scale = 1;
 
             % check varargin for 'comp' or 'chan'
             isind = false;

--- a/gui/fastplot/fastplot.m
+++ b/gui/fastplot/fastplot.m
@@ -184,7 +184,7 @@ classdef fastplot < handle
         end
 
 
-        function refresh(obj, mthd)
+        function refresh(obj, elements, mthd)
             % refresh fastplot window
 
             % CHANGE should check if sth actually changed
@@ -192,9 +192,22 @@ classdef fastplot < handle
             % during re-plotting:
             % always use set 'XData', 'YData'
             obj.window.span = obj.window.lims(1):obj.window.lims(2);
+            if ~exist('elements', 'var')
+                elements = {'all'};
+            elseif ~iscell(elements)
+                elements = {elements};
+            end
             
             if ~exist('mthd', 'var')
                 mthd = obj.scrollmethod;
+            end
+
+            if any(strcmp('all', elements))
+                refresh_elem = true(4, 1);
+            else
+                elem_order = {'signal', 'events', 'limits', 'marks'}';
+                refresh_elem = cellfun(@(x) any(strcmp(x, elements)), ...
+                    elem_order);
             end
             
             % tic;
@@ -214,9 +227,9 @@ classdef fastplot < handle
                             dat(obj.window.span, i), 'HitTest', 'off');
                     end
             end
-            obj.plotevents();
-            obj.plot_epochlimits();
-            obj.plot_marks();
+            if refresh_elem(2); obj.plotevents(); end;
+            if refresh_elem(3); obj.plot_epochlimits(); end;
+            if refresh_elem(4); obj.plot_marks(); end;
             % timetaken = toc;
             % fprintf('time taken: %f\n', timetaken);
         end


### PR DESCRIPTION
Adds ability to scale signal with `-` and `=`/`+` buttons.
This works with numerical prefixes too - `14-` scales signal down by 14 steps.
In the future `ss` will go to set step menu where signal scaling step could be defined.