### PR TITLE
tempfiles

### DIFF
--- a/db/db_epoch.m
+++ b/db/db_epoch.m
@@ -1,0 +1,116 @@
+function EEG = db_epoch(EEG, db, r, segmentinfo)
+
+% DB_EPOCH is the function used by eegDb for epoching
+% files are epoched automatically when they are recovered
+% FIXHELPINFO
+
+
+if femp(db(r), 'epoch')
+
+    % defaults
+    % --------
+    code_id = '\code:'; 
+    cidlen = length(code_id);
+
+    if ~exist('r', 'var')
+        r = 1;
+    end
+
+    if ~exist('segmentinfo', 'var')
+        % is segment given:
+        if isfield(db(r).epoch, 'segment') && ...
+                ~isempty(db(r).epoch.segment) && isnumeric(db(r).epoch.segment)
+            segmentinfo = true;
+        end
+    end
+
+    % windowing 
+    % ---------
+    % (consecutive epochs, not event locked)
+    if femp(db(r).epoch, 'locked') && ~db(r).epoch.locked
+        
+        % ==============
+        % onesec options
+        options.filename = EEG;
+        options.fill = true;
+        
+        flds = {'filter', 'winlen', 'distance',...
+            'leave', 'eventname'};
+        
+        % checking fields for onesecepoch
+        for f = 1:length(flds)
+            if femp(db(r).epoch, flds{f})
+                options.(flds{f}) = db(r).epoch.(flds{f});
+            end
+        end
+
+        % if prerej is present then no need to use distance
+        if femp(db(r).reject, 'pre')
+            options.distance = [];
+        end
+        
+        % ===================
+        % call to onesecepoch
+        EEG = onesecepoch(options);
+        clear options
+        
+    elseif ~isempty(db(r).epoch.events) && ...
+            ~isempty(db(r).epoch.limits)
+        
+        % ==================
+        % classical epoching
+        epoc = db(r).epoch.events;
+        
+        % checking for code generator of epochs
+        % ADD - function handle for epoching?
+        %       or maybe not necessary - there is an
+        %       option for user-defined function
+        if ischar(epoc) && length(epoc) > cidlen && ...
+                strcmp(epoc(1:cidlen), code_id)
+            
+            epoc = eval(epoc(cidlen+1:end));
+        end
+        
+        EEG = db_fastepoch(EEG, epoc, db(r).epoch.limits);
+        
+        % =======================
+        % checking for segmenting
+        if segmentinfo && ~nosegment
+            EEG = segmentEEG(EEG, db(r).epoch.segment);
+        end
+    end
+end
+
+% CHANGE
+% [ ] if we segment then orig_numep should be adjusted too
+% [ ] instead of numep this all can be done in a smarter way
+%                1) generally - onesec can add numep too
+%                2) numep can be inferred from length of rejections
+%                   in db(r)!
+%                3) ...
+% [ ] in the current version only onesecepoching is checked
+%     for while in future releases we want to include also
+%     conditional epoch extraction (only correct etc.) which
+%     is another prerej
+%
+%
+% ======================
+% adding orig_numep info
+%
+% (this is later used when rejections are added
+%  using a recovered file that has some of the
+%  rejections already removed)
+%
+% if epoched signal add orig_numep
+EEG.etc.orig_numep = size(EEG.data, 3);
+
+% if onesecepoch was perfromed add onesec info
+if femp(db(r).epoch, 'locked') && ~db(r).epoch.locked
+    
+    % either prerej is nonempty  % or what?
+    if femp(db(r).reject, 'pre')
+        % there is some info about prerej,
+        % we correct orig_numep
+        EEG.etc.orig_numep = EEG.etc.orig_numep - length(db(r).reject.pre);
+    end
+end

--- a/db/paths/db_temp_get.m
+++ b/db/paths/db_temp_get.m
@@ -1,0 +1,104 @@
+function [tempdb, match] = db_temp_get(db, r)
+
+% DB_TEMP_GET gives info on relevant tempfile for db
+% record r.
+%
+% usage
+% -----
+% temp = db_temp_get(db, r);
+%
+% input
+% -----
+% db - *structure*; eegDb database
+% r  - *integer*; record number
+%
+% output
+% ------
+% temp - *structure*; tempfile info, with fields:
+%     .filename
+%     .filepath
+%     .filter
+%     .cleanline
+%     .epoch
+
+
+
+tempdb = [];
+match = 0;
+
+if femp(db(r).datainfo, 'tempfiles')
+	% some tempfiles are present, check which 
+	% ones are present on disc
+	temp = db(r).datainfo.tempfiles;
+	tempok = false(1, length(temp));
+	for t = 1:length(temp)
+		tempok(t) = ~isempty(get_valid_path(...
+			temp(t).filepath, ...
+			'file', temp(t).filename, ...
+			'noerror', true));
+	end
+	temp = temp(tempok);
+
+	if isempty(temp)
+		return
+	end
+
+	% check which tempfile matches the 
+	% current database pipeline
+
+	% get filtering and epoching from the current record:
+	tst = struct('filter', [], 'epoch', [], 'cleanline', []);
+
+	% epoching
+	tst.epoch = db_getepoching(db(r));
+
+	% filtering (should CHANGE to db_get later on)
+	in = cellfun(@(x) femp(x, 'filter'), {db(r), db(r).datainfo});
+	in(3) = femp(db(r).datainfo, 'filtered');
+
+	if any(in)
+		if in(1)
+			tst.filter = db(r).filter;
+		elseif in(2)
+			tst.filter = db(r).datainfo.filter;
+		elseif in(3)
+			tst.filter = db(r).datainfo.filtered;
+		end
+	end
+
+	% cleanline
+	if femp(db(r).datainfo, 'cleanline')
+		tst.cleanline = db(r).datainfo.cleanline;
+	end
+
+	% only filtering and epoching are considered
+	checkflds = {'cleanline', 'filter', 'epoch'};
+	test_temp = false(length(checkflds), length(temp));
+
+	for f = 1:length(checkflds)
+		test_temp(f, :) = cellfun(@(x) isequal(x, ...
+			tst.(checkflds{f})), {temp.(checkflds{f})});
+	end
+	good_temp = all(test_temp(1:2, :), 1);
+	best_temp = all(test_temp, 1);
+
+	ind = [];
+	% choose first one matching (CHANGE!)
+	if any(best_temp)
+		ind = find(best_temp, 1);
+		match = 2;
+	elseif any(good_temp)
+		ind = find(good_temp, 1);
+		match = 1;
+	end
+
+	if ~isempty(ind)
+		% give tempdb
+		tempdb = struct();
+		tempdb.filename = temp(ind).filename;
+		tempdb.filepath = temp(ind).filepath;
+		tempdb.filter = temp(ind).filter;
+		tempdb.epoch = temp(ind).epoch;
+		tempdb.cleanline = temp(ind).cleanline;
+	end
+end

--- a/db/paths/get_valid_path.m
+++ b/db/paths/get_valid_path.m
@@ -1,6 +1,13 @@
-function pth = get_valid_path(PTH)
+function pth = get_valid_path(PTH, varargin)
 
 % FIXHELPINFO
+% additional args
+opt.file = [];
+opt.noerror = false;
+if nargin > 1
+    opt = parse_arse(varargin, opt);
+end
+iffile = ~isempty(opt.file);
 
 % if not cell - close in a cell
 if ~iscell(PTH)
@@ -12,12 +19,23 @@ fnd = false;
 for p = 1:length(PTH)
     % and test isdir() on them
     if isdir(PTH{p})
+        % if filecheck, check if file is present:
+        if iffile
+            fls = dir(PTH{p});
+            fileok = any(strcmp(opt.file, {fls(~[fls.isdir]).name}));
+        end
+
         % if it is dir, stop looking
-        pth = PTH{p};
-        fnd = true;
-        break
+        if ~iffile || fileok
+            pth = PTH{p};
+            fnd = true;
+            break
+        end
     end
 end
-if ~fnd
-    error('Could not find the correct path');
+
+if ~opt.noerror
+    if ~fnd
+        error('Could not find the correct path');
+    end
 end

--- a/db/paths/get_valid_path.m
+++ b/db/paths/get_valid_path.m
@@ -1,6 +1,37 @@
 function pth = get_valid_path(PTH, varargin)
 
-% FIXHELPINFO
+% GET_VALID_PATH checks which path is valid on a given machine
+%
+% usage
+% -----
+% pth = get_valid_path(PTH, ...);
+%
+% input
+% -----
+% PTH - *string* or *cell array of strings*; path string(s)
+%
+% ... - additional key - value pairs
+%
+% key-value pairs
+% ---------------
+% 'file'    - *string*; filename that should be present
+%             in the valid path
+% 'noerror' - *logical*; whether NOT to throw an error when valid
+%             path was not found
+%             default: false (error is thrown)
+%
+% examples
+% --------
+% check which path to Dropbox is correct on given machine:
+% PTH = {'D:\Dropbox\', 'C:\Users\Kant\Dropbox\'};
+% validpath = get_valid_path(PTH);
+%
+% check which folder exists AND has file 'data.set' inside:
+% PTH = {'C:\DATA\superstudy\', 'C:\DATA\otherstudy\'};
+% validpath = get_valid_path(PTH, 'file', 'data.set');
+%
+% see also: isdir
+
 % additional args
 opt.file = [];
 opt.noerror = false;

--- a/db/recoverEEG.m
+++ b/db/recoverEEG.m
@@ -60,14 +60,6 @@ function [EEG, orig_db] = recoverEEG(db, r, varargin)
 %     covery.
 %
 
-% VERSION info:
-% 2014.01.27 --> compressed icaweights temp usage when
-%                interpolating
-% 2014.03.25 --> moved interpolation before epoching
-%                added postfilter between interpolation
-%                and epoching
-% 2014.06.22 --> changed path checking loop to db_path 
-%                function call
 
 % TODOs:
 % [ ] path availability and eeglab inteface presence
@@ -90,9 +82,6 @@ function [EEG, orig_db] = recoverEEG(db, r, varargin)
 %     visible
 % [ ] remove the paths to eeglab in 'local' or recover
 %     previous path?
-% [ ] CHANGE 'loaded' behavior - now it only adds ICA,
-%     should it perform other modifs (filtering, epoching,
-%     etc.)? How should 'loaded' generally work??
 
 
 %% defaults:
@@ -137,10 +126,9 @@ if nargin > 2
     reslt = strcmp('dir', varargin);
     if sum(reslt)>0
         overr_dir = true;
-        path = varargin{find(reslt) + 1};
+        additional_path = varargin{find(reslt) + 1};
     end
     
-    %zmienilam cos - tzn co? [Miko]
     % ADD - check for path override
 end
 
@@ -221,7 +209,7 @@ end
 % ====================================
 % if user chooses to override filepath
 if overr_dir
-    db(r).filepath = path;
+    db(r).filepath = additional_path;
 end
 
 % ================================================
@@ -321,8 +309,7 @@ if ~loaded
     % checking filtering
     if ~nofilter
         % optional filtering:
-        if isfield(db(r), 'filter') && ...
-                ~isempty(db(r).filter)
+        if femp(db(r), 'filter')
             
             % setting up filter:
             filt = db(r).filter;

--- a/db/recoverEEG.m
+++ b/db/recoverEEG.m
@@ -100,11 +100,10 @@ prerej = false; cleanl = false;
 local = false; nofilter = false;
 loaded = false; addfilt = [];
 overr_dir = false; noICA = false;
-code_id = '\code:'; ICAnorem = false;
+ICAnorem = false;
 interp = false; segment = false;
 nosegment = false;
 
-cidlen = length(code_id);
 
 %% checking additional arguments
 if nargin > 2
@@ -447,94 +446,9 @@ if femp(db(r), 'postfilter')
 end
 
 %% epoching
-if femp(db(r), 'epoch')
-    if femp(db(r).epoch, 'locked') && ~db(r).epoch.locked
-        
-        % ==============
-        % onesec options
-        options.filename = EEG;
-        options.fill = true;
-        
-        flds = {'filter', 'winlen', 'distance',...
-            'leave', 'eventname'};
-        
-        % checking fields for onesecepoch
-        for f = 1:length(flds)
-            if femp(db(r).epoch, flds{f})
-                options.(flds{f}) = db(r).epoch.(flds{f});
-            end
-        end
-        
-        % if prerej is present then no need to use distance
-        if femp(db(r).reject, 'pre')
-            options.distance = [];
-        end
-        
-        % ===================
-        % call to onesecepoch
-        EEG = onesecepoch(options);
-        clear options
-        
-    elseif ~isempty(db(r).epoch.events) && ...
-            ~isempty(db(r).epoch.limits)
-        
-        % ==================
-        % classical epoching
-        epoc = db(r).epoch.events;
-        
-        % checking for code generator of epochs
-        % ADD - function handle for epoching?
-        %       or maybe not necessary - there is an
-        %       option for user-defined function
-        if ischar(epoc) && length(epoc) > cidlen && ...
-                strcmp(epoc(1:cidlen), code_id)
-            
-            epoc = eval(epoc(cidlen+1:end));
-        end
-        
-        EEG = db_fastepoch(EEG, epoc, db(r).epoch.limits);
-        
-        % =======================
-        % checking for segmenting
-        if segment && ~nosegment
-            EEG = segmentEEG(EEG, db(r).epoch.segment);
-        end
-    end
+    EEG = db_epoch(EEG, db, r, min(segment, ~nosegment));
 end
 
-% CHANGE
-% [ ] if we segment then orig_numep should be adjusted too
-% [ ] instead of numep this all can be done in a smarter way
-%                1) generally - onesec can add numep too
-%                2) numep can be inferred from length of rejections
-%                   in db(r)!
-%                3) ...
-% [ ] in the current version only onesecepoching is checked
-%     for while in future releases we want to include also
-%     conditional epoch extraction (only correct etc.) which
-%     is another prerej
-%
-%
-% ======================
-% adding orig_numep info
-%
-% (this is later used when rejections are added
-%  using a recovered file that has some of the
-%  rejections already removed)
-%
-% if epoched signal add orig_numep
-EEG.etc.orig_numep = size(EEG.data, 3);
-
-% if onesecepoch was perfromed add onesec info
-if femp(db(r).epoch, 'locked') && ~db(r).epoch.locked
-    
-    % either prerej is nonempty  % or what?
-    if femp(db(r).reject, 'pre')
-        % there is some info about prerej,
-        % we correct orig_numep
-        EEG.etc.orig_numep = EEG.etc.orig_numep - length(db(r).reject.pre);
-    end
-end
 
 %% removing bad epochs
 if ~prerej && ~isempty(db(r).reject.all)

--- a/db/recoverEEG.m
+++ b/db/recoverEEG.m
@@ -103,6 +103,7 @@ overr_dir = false; noICA = false;
 ICAnorem = false;
 interp = false; segment = false;
 nosegment = false;
+haspostfilter = femp(db(r), 'postfilter');
 
 
 %% checking additional arguments
@@ -366,6 +367,10 @@ if ~loaded
     end
 end
 
+%% epoching if not haspostfilter
+if ~haspostfilter
+    EEG = db_epoch(EEG, db, r, min(segment, ~nosegment));
+end
 
 %% adding ICA info
 add_comprej = false;
@@ -446,6 +451,7 @@ if femp(db(r), 'postfilter')
 end
 
 %% epoching
+if haspostfilter
     EEG = db_epoch(EEG, db, r, min(segment, ~nosegment));
 end
 

--- a/gui/compsel/linkfun_compexplore.m
+++ b/gui/compsel/linkfun_compexplore.m
@@ -42,7 +42,7 @@ if ~isreco
 	drawnow;
 
 	% recover
-	h.EEG = recoverEEG(h.db, h.r, 'local', 'ICAnorem');
+	[h.EEG, h.db] = recoverEEG(h.db, h.r, 'local', 'tempsave', 'ICAnorem');
     h.rEEG = h.r;
 
     % update winrej handles

--- a/gui/db_gui.m
+++ b/gui/db_gui.m
@@ -688,6 +688,7 @@ function runICA_Callback(hObject, eventdata, handles)
 % handles    structure with handles and user data (see GUIDATA)
 
 % check selection
+handles = guidata(hObject);
 if isempty(handles.selected)
     sel = handles.r;
 else
@@ -779,7 +780,6 @@ for c = 1:length(cansel)
             guidata(hObject, handles);
         end
     end
-    end
 end
 
 % update text display
@@ -791,6 +791,7 @@ guidata(hObject, handles);
 
 % refresh GUI
 db_gui_refresh(handles);
+end
 
 % --------------------------------------------------------------------
 function vers_Callback(hObject, eventdata, handles)

--- a/gui/db_gui.m
+++ b/gui/db_gui.m
@@ -218,7 +218,8 @@ else
         drawnow;
         
         % RECOVER EEG data
-        handles.EEG = recoverEEG(handles.db, handles.r, 'local', handles.recovopts{:});
+        [handles.EEG, handles.db] = recoverEEG(handles.db, handles.r, ...
+            'local', 'tempsave', handles.recovopts{:});
         handles.rEEG = handles.r;
         rEEG = handles.rEEG;
         

--- a/gui/db_gui.m
+++ b/gui/db_gui.m
@@ -410,6 +410,8 @@ function col_butt_Callback(hObject, eventdata, handles)
 % --- Executes on button press in next_butt.
 function next_butt_Callback(hObject, eventdata, handles)
 
+handles = guidata(hObject);
+
 if handles.r < length(handles.db)
     handles.r = handles.r + 1;
     
@@ -423,6 +425,8 @@ end
 
 % --- Executes on button press in prev_butt.
 function prev_butt_Callback(hObject, eventdata, handles)
+
+handles = guidata(hObject);
 
 if handles.r > 1
     handles.r = handles.r - 1;


### PR DESCRIPTION
#### About this PR:
This PR introduces **tempfiles** - temporary files with filtered & epoched data stored in `tempfiles` folder. Using tempfiles significantly speeds up recovering files the second time.
Using tempfiles from the command line:
```matlab
[EEG, db] = recoverEEG(db, 3, 'tempsave');
```
Infomation about the tempfiles is stored in `db(r).datainfo.tempfiles` in the database and `EEG.etc.temp` in the recovered file. So you can add tempfile info to db even if you forgot to get updated `db` from `recoverEEG` you can still get it from `EEG` and save in the `db`.

#### TODOs:
- [ ] "rooted" paths - for example `+tempfiles` meaning any valid path from `db(r).filepath` but with `tempfiles` folder added to the path end.
- [ ] db_gui options to use tempfiles
- [ ] function to clear unused tempfiles (from `db` and from hard drive)